### PR TITLE
Windows support

### DIFF
--- a/Makefile_windows
+++ b/Makefile_windows
@@ -1,0 +1,68 @@
+# This Makefile will build a DLL and an application which makes use of the DLL.
+
+DLL_NAME := code128
+EXE_NAME := code128png
+
+# Object files to create for the executable
+DLL_OBJS = $(DLL_NAME).o
+EXE_OBJS = $(EXE_NAME).o
+
+# Warnings to be raised by the C compiler
+WARNS = -Wall -fpic -Wextra -march=$(ARCH)
+
+
+CODE128PNG_INCLUDE_DIRS := .
+CODE128PNG_LIBRARY_DIRS := .
+CODE128PNG_LIBRARIES := png ${DLL_NAME}
+
+EXE_CFLAGS += $(foreach includedir,$(CODE128PNG_INCLUDE_DIRS),-I$(includedir))
+EXE_LDFLAGS += $(foreach librarydir,$(CODE128PNG_LIBRARY_DIRS),-L$(librarydir))
+EXE_LDFLAGS += $(foreach library,$(CODE128PNG_LIBRARIES),-l$(library))
+
+
+
+# Names of tools to use when building
+CC = cc
+DLL = lib$(DLL_NAME)-$(ARCH).dll
+EXE = $(EXE_NAME)-$(ARCH).exe
+
+# Compiler flags
+EXE_CFLAGS += -O2 -std=c99 ${WARNS}
+DLL_CFLAGS += ${EXE_CFLAGS} -D ADD_EXPORTS
+
+#ifeq ($(OS), Windows_NT)
+#DLL_CFLAGS += -D WINDOWS
+#endif
+
+# Linker flags
+DLL_LDFLAGS += -shared -s -Wl,--subsystem,windows,--out-implib,lib$(DLL_NAME).a
+EXE_LDFLAGS += -s -Wl,--subsystem,console
+
+
+default: ${DLL} ${EXE}
+
+# Delete all build output
+clean:
+	if exist *.dll del /q *.dll
+	if exist *.o del /q *.o
+	if exist *.a del /q *.a
+	if exist *.exe del /q *.exe
+
+
+# Compile object files for DLL
+$(DLL_NAME).o: $(DLL_NAME).c $(DLL_NAME).h
+	${CC} ${DLL_CFLAGS} -c "$<" -o "$@"
+
+# Build the DLL
+${DLL}: ${DLL_OBJS}
+	${CC} -o "$@" ${DLL_OBJS} ${DLL_LDFLAGS}
+
+# Buld the executable
+${EXE}: ${EXE_OBJS}
+	${CC} ${EXE_CFLAGS} -o "$@" ${EXE_OBJS} ${EXE_LDFLAGS}
+
+.PHONY: clean default
+
+all:
+	$(MAKE) ARCH=x86-64 default
+	$(MAKE) ARCH=x86-64-v4 default

--- a/README.md
+++ b/README.md
@@ -38,8 +38,27 @@ Debian/Ubuntu, run:
 sudo apt install libpng-dev
 ```
 
+On Windows, with MSYS2, run:
+```sh
+pacman -S --needed base-devel mingw-w64-x86_64-toolchain
+pacman -S mingw-w64-x86_64-libpng
+```
+
+Details on how to install and setup MSYS2 environment on Windows can be found
+[here](https://code.visualstudio.com/docs/languages/cpp) and
+[here](https://www.freecodecamp.org/news/how-to-install-c-and-cpp-compiler-on-windows/) .
+
+
 Then run `make`. The result is a test program that creates `png` files of
 barcode data passed on the commandline.
+
+On Windows, to build the libraries and the test program for different architectures,
+you should open Powershell and run:
+
+```sh
+mingw-32-make.exe all
+```
+
 
 The regression tests require [zbar](http://zbar.sourceforge.net/). Install
 `zbar` on Debian/Ubuntu by:

--- a/code128.c
+++ b/code128.c
@@ -170,7 +170,7 @@ struct code128_state {
     size_t maxlength;
 };
 
-size_t code128_estimate_len(const char *s)
+size_t ADDCALL code128_estimate_len(const char *s)
 {
     return CODE128_QUIET_ZONE_LEN
            + CODE128_CHAR_LEN // start code
@@ -434,7 +434,7 @@ static void code128_do_step(struct code128_state *state)
     }
 }
 
-size_t code128_encode_raw(const char *s, char *out, size_t maxlength)
+size_t ADDCALL code128_encode_raw(const char *s, char *out, size_t maxlength)
 {
     struct code128_state state;
 
@@ -533,7 +533,7 @@ size_t code128_encode_raw(const char *s, char *out, size_t maxlength)
  *
  * @return the length of barcode data in bytes
  */
-size_t code128_encode_gs1(const char *s, char *out, size_t maxlength)
+size_t ADDCALL code128_encode_gs1(const char *s, char *out, size_t maxlength)
 {
     char raw[strlen(s) + 1];
 

--- a/code128.h
+++ b/code128.h
@@ -25,6 +25,28 @@
 
 #include <stddef.h>
 
+// credits to https://www.transmissionzero.co.uk/computing/building-dlls-with-mingw/
+#ifdef _WIN32
+
+  /* You should define ADD_EXPORTS *only* when building the DLL. */
+  #ifdef ADD_EXPORTS
+    #define ADDAPI __declspec(dllexport)
+  #else
+    #define ADDAPI __declspec(dllimport)
+  #endif
+
+  /* Define calling convention in one place, for convenience. */
+  #define ADDCALL __cdecl
+
+#else /* _WIN32 not defined. */
+
+  /* Define with no value on non-Windows OSes. */
+  #define ADDAPI
+  #define ADDCALL
+
+#endif
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -36,9 +58,9 @@ extern "C" {
 #define CODE128_FNC3 '\xf3'
 #define CODE128_FNC4 '\xf4'
 
-size_t code128_estimate_len(const char *s);
-size_t code128_encode_gs1(const char *s, char *out, size_t maxlength);
-size_t code128_encode_raw(const char *s, char *out, size_t maxlength);
+ADDAPI size_t ADDCALL code128_estimate_len(const char *s);
+ADDAPI size_t ADDCALL code128_encode_gs1(const char *s, char *out, size_t maxlength);
+ADDAPI size_t ADDCALL code128_encode_raw(const char *s, char *out, size_t maxlength);
 
 #ifdef __cplusplus
 }

--- a/code128png.c
+++ b/code128png.c
@@ -21,13 +21,31 @@
 // EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdio.h>
-#include <err.h>
 #include <stdlib.h>
 #include <string.h> // needed for memset()
-
 #include <png.h>
 
 #include "code128.h"
+
+#ifndef _WIN32
+// Windows does not support err.h
+#include <err.h>
+#else
+
+// Mimic behavior
+void
+errx(int eval, const char *fmt, ...)
+{
+    fprintf(stderr, fmt, strerror(errno));
+    exit(eval);
+}
+
+void
+warnx(const char *fmt, ...)
+{
+    fprintf(stderr, fmt, strerror(errno));
+}
+#endif
 
 static void png_error_callback(png_structp png_ptr, const char *msg)
 {
@@ -61,7 +79,7 @@ int main(int argc, char *argv[])
 
     FILE *fp = fopen(argv[1], "wb");
     if (!fp)
-        err(EXIT_FAILURE, "can't open output");
+        errx(EXIT_FAILURE, "can't open output");
 
     png_structp png_ptr = png_create_write_struct
                           (PNG_LIBPNG_VER_STRING, NULL,


### PR DESCRIPTION
Added a different makefile to build under MSYS2 on Windows 11 .

Needed to change API declaration to correctly export under Windows (ADDAPI, ADDCALL, wanx and errx), keeping Linux being able to build.

Updated README with useful info for Windows OS.

With those changes, I've built libraries and test application under Windows 11 and Linux.