### PR TITLE
make format-code

### DIFF
--- a/code128.c
+++ b/code128.c
@@ -40,7 +40,7 @@
 #define CODE128_MIN_ENCODE_LEN (CODE128_QUIET_ZONE_LEN * 2 + CODE128_CHAR_LEN * 2 + CODE128_STOP_CODE_LEN)
 
 static const int code128_pattern[] = {
-        // value: pattern,     bar/space widths
+    // value: pattern,     bar/space widths
     1740, //   0: 11011001100, 212222
     1644, //   1: 11001101100, 222122
     1638, //   2: 11001100110, 222221

--- a/code128.h
+++ b/code128.h
@@ -28,21 +28,21 @@
 // credits to https://www.transmissionzero.co.uk/computing/building-dlls-with-mingw/
 #ifdef _WIN32
 
-  /* You should define ADD_EXPORTS *only* when building the DLL. */
-  #ifdef ADD_EXPORTS
-    #define ADDAPI __declspec(dllexport)
-  #else
-    #define ADDAPI __declspec(dllimport)
-  #endif
+/* You should define ADD_EXPORTS *only* when building the DLL. */
+#ifdef ADD_EXPORTS
+#define ADDAPI __declspec(dllexport)
+#else
+#define ADDAPI __declspec(dllimport)
+#endif
 
-  /* Define calling convention in one place, for convenience. */
-  #define ADDCALL __cdecl
+/* Define calling convention in one place, for convenience. */
+#define ADDCALL __cdecl
 
 #else /* _WIN32 not defined. */
 
-  /* Define with no value on non-Windows OSes. */
-  #define ADDAPI
-  #define ADDCALL
+/* Define with no value on non-Windows OSes. */
+#define ADDAPI
+#define ADDCALL
 
 #endif
 


### PR DESCRIPTION
Ran `make format-code`

**Edit:** Tbh I prefer the formatting of the indented preprocessor directives. Maybe a better way would be to ignore certain regions in astyle