### PR TITLE
Fix fnc3 and win versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 CFLAGS ?= -O2 -Wall -Wextra -Wno-implicit-fallthrough
 
 MAJOR := 1
-MINOR := 0
+MINOR := 1
 NAME := code128
 VERSION := $(MAJOR).$(MINOR)
 

--- a/Makefile_windows
+++ b/Makefile_windows
@@ -1,5 +1,8 @@
 # This Makefile will build a DLL and an application which makes use of the DLL.
 
+MAJOR := 1
+MINOR := 1
+VERSION := $(MAJOR).$(MINOR)
 DLL_NAME := code128
 EXE_NAME := code128png
 
@@ -23,7 +26,7 @@ EXE_LDFLAGS += $(foreach library,$(CODE128PNG_LIBRARIES),-l$(library))
 
 # Names of tools to use when building
 CC = cc
-DLL = lib$(DLL_NAME)-$(ARCH).dll
+DLL = lib$(DLL_NAME)_v$(VERSION)-$(ARCH).dll
 EXE = $(EXE_NAME)-$(ARCH).exe
 
 # Compiler flags
@@ -57,7 +60,7 @@ $(DLL_NAME).o: $(DLL_NAME).c $(DLL_NAME).h
 ${DLL}: ${DLL_OBJS}
 	${CC} -o "$@" ${DLL_OBJS} ${DLL_LDFLAGS}
 
-# Buld the executable
+# Build the executable
 ${EXE}: ${EXE_OBJS}
 	${CC} ${EXE_CFLAGS} -o "$@" ${EXE_OBJS} ${EXE_LDFLAGS}
 

--- a/code128.c
+++ b/code128.c
@@ -244,7 +244,7 @@ static signed char code128a_ascii_to_code(char value)
 {
     if (value >= ' ' && value <= '_')
         return value - ' ';
-    else if (value < ' ')
+    else if (value >= 0 && value < ' ')
         return value + 64;
     else if (value == CODE128_FNC1)
         return 102;
@@ -352,7 +352,7 @@ static int code128_do_c_step(struct code128_step *base, int prev_ix, int ix)
     step->code = code128c_ascii_to_code(previous_step->next_input);
     if (step->code < 0) {
         return 0;
-   }
+    }
 
     step->prev_ix = prev_ix;
     step->next_input = previous_step->next_input + 1;

--- a/code128.c
+++ b/code128.c
@@ -244,7 +244,7 @@ static signed char code128a_ascii_to_code(char value)
 {
     if (value >= ' ' && value <= '_')
         return value - ' ';
-    else if (value >= 0 && value < ' ')
+    else if (value < ' ')
         return value + 64;
     else if (value == CODE128_FNC1)
         return 102;

--- a/code128.c
+++ b/code128.c
@@ -296,8 +296,9 @@ static int code128_do_a_step(struct code128_step *base, int prev_ix, int ix)
         return 0;
 
     step->code = code128a_ascii_to_code(value);
-    if (step->code < 0)
+    if (step->code < 0) {
         return 0;
+    }
 
     step->prev_ix = prev_ix;
     step->next_input = previous_step->next_input + 1;
@@ -320,8 +321,9 @@ static int code128_do_b_step(struct code128_step *base, int prev_ix, int ix)
         return 0;
 
     step->code = code128b_ascii_to_code(value);
-    if (step->code < 0)
+    if (step->code < 0) {
         return 0;
+    }
 
     step->prev_ix = prev_ix;
     step->next_input = previous_step->next_input + 1;
@@ -344,8 +346,9 @@ static int code128_do_c_step(struct code128_step *base, int prev_ix, int ix)
         return 0;
 
     step->code = code128c_ascii_to_code(previous_step->next_input);
-    if (step->code < 0)
+    if (step->code < 0) {
         return 0;
+   }
 
     step->prev_ix = prev_ix;
     step->next_input = previous_step->next_input + 1;
@@ -380,8 +383,9 @@ static void code128_do_step(struct code128_state *state)
     struct code128_step *step = &state->steps[state->current_ix];
     if (*step->next_input == 0) {
         // Done, so see if we have a new shortest encoding.
-        if ((step->len < state->maxlength) ||
-                (state->best_ix < 0 && step->len == state->maxlength)) {
+        // Fix for some FNC3 starting codes
+        if ((step->len - CODE128_CHAR_LEN < state->maxlength) ||
+                (state->best_ix < 0 && step->len - CODE128_CHAR_LEN == state->maxlength)) {
             state->best_ix = state->current_ix;
 
             // Update maxlength to avoid considering anything longer
@@ -483,7 +487,8 @@ size_t ADDCALL code128_encode_raw(const char *s, char *out, size_t maxlength)
     } while (state.current_ix != state.todo_ix);
 
     // If no best_step, then fail.
-    if (state.best_ix < 0) {
+    if (state.best_ix < 0)
+    {
         free(state.steps);
         return 0;
     }

--- a/code128.c
+++ b/code128.c
@@ -260,7 +260,8 @@ static signed char code128a_ascii_to_code(char value)
 
 static signed char code128b_ascii_to_code(char value)
 {
-    if (value >= 32) // value <= 127 is implied
+    /* value <= 127 is required to work both on x86 and on ARM. */
+    if ((value >= 32) && (value <= 127))
         return value - 32;
     else if (value == CODE128_FNC1)
         return 102;

--- a/code128.c
+++ b/code128.c
@@ -215,6 +215,7 @@ static signed char code128_switch_code(char from_mode, char to_mode)
         case CODE128_MODE_C:
             return 99;
         }
+        break;
 
     case CODE128_MODE_B:
         switch (to_mode) {
@@ -223,6 +224,7 @@ static signed char code128_switch_code(char from_mode, char to_mode)
         case CODE128_MODE_C:
             return 99;
         }
+        break;
 
     case CODE128_MODE_C:
         switch (to_mode) {
@@ -231,6 +233,7 @@ static signed char code128_switch_code(char from_mode, char to_mode)
         case CODE128_MODE_A:
             return 101;
         }
+        break;
     }
 
     assert(0); // Invalid mode switch

--- a/code128.c
+++ b/code128.c
@@ -384,8 +384,9 @@ static void code128_do_step(struct code128_state *state)
     if (*step->next_input == 0) {
         // Done, so see if we have a new shortest encoding.
         // Fix for some FNC3 starting codes
-        if ((step->len - CODE128_CHAR_LEN < state->maxlength) ||
-                (state->best_ix < 0 && step->len - CODE128_CHAR_LEN == state->maxlength)) {
+        size_t step_len = step->len - CODE128_CHAR_LEN;
+        if ((step_len < state->maxlength) ||
+                (state->best_ix < 0 && step_len == state->maxlength)) {
             state->best_ix = state->current_ix;
 
             // Update maxlength to avoid considering anything longer


### PR DESCRIPTION
- some codes that start with FNC3 returns "Invalid character in string"
- add version number to Windows build